### PR TITLE
Add conditional writes for the checkpoint.

### DIFF
--- a/experimental/gcp-log/function.go
+++ b/experimental/gcp-log/function.go
@@ -343,7 +343,9 @@ func Integrate(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
-func signAndWrite(ctx context.Context, cp *fmtlog.Checkpoint, cpNote note.Note, s note.Signer, client *storage.Client, origin string) error {
+// signAndWrite signs a checkpoint and writes the new checkpoint to GCS.
+func signAndWrite(ctx context.Context, cp *fmtlog.Checkpoint, cpNote note.Note,
+	s note.Signer, client *storage.Client, origin string) error {
 	cp.Origin = origin
 	cpNote.Text = string(cp.Marshal())
 	cpNoteSigned, err := note.Sign(&cpNote, s)


### PR DESCRIPTION
After this PR, the Integrate function may fail if the generation precondition of the new checkpoint does not match the last read checkpoint.

To tighten that, we should add a [retry](https://cloud.google.com/workflows/docs/reference/syntax/retrying) policy for the Cloud Build step (e.g. [here](https://github.com/transparency-dev/armored-witness-applet/blob/a8b91dd9b5bb73b0802b4114ee52549204c077f6/release/cloudbuild_ci.yaml#L120-L136)) to Integrate a new log entry.