### PR TITLE
Fix zero hash

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -92,6 +92,11 @@ func NewProofBuilder(ctx context.Context, cp log.Checkpoint, h compact.HashFn, f
 		nodeCache: newNodeCache(tf, cp.Size),
 		h:         h,
 	}
+	// Can't re-create the root of a zero size checkpoint other than by convention,
+	// so return early here in that case.
+	if cp.Size == 0 {
+		return pb, nil
+	}
 
 	hashes, err := FetchRangeNodes(ctx, cp.Size, tf)
 	if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	testOrigin      = "Log Checkpoint v0"
+	testOrigin      = "example.com/testdata"
 	testLogVerifier = mustMakeVerifier("astra+cad5a3d2+AZJqeuyE/GnknsCNh1eCtDtwdAwKBddOlS8M2eI1Jt4b")
 	// Built using serverless/testdata/build_log.sh
 	testRawCheckpoints, testCheckpoints = mustLoadTestCheckpoints()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -48,7 +48,7 @@ func mustMakeVerifier(vs string) note.Verifier {
 
 func mustLoadTestCheckpoints() ([][]byte, []log.Checkpoint) {
 	raws, cps := make([][]byte, 0), make([]log.Checkpoint, 0)
-	for i := 1; ; i++ {
+	for i := 0; ; i++ {
 		cpName := fmt.Sprintf("checkpoint.%d", i)
 		r, err := testLogFetcher(context.Background(), cpName)
 		if err != nil {
@@ -333,5 +333,18 @@ func TestNodeCacheHandlesInvalidRequest(t *testing.T) {
 
 	if _, err := nc.GetNode(ctx, compact.NewNodeID(0, 1)); err == nil {
 		t.Error("got no error, want error because ID is out of range")
+	}
+}
+
+func TestHandleZeroRoot(t *testing.T) {
+	zeroCP := testCheckpoints[0]
+	if zeroCP.Size != 0 {
+		t.Fatal("BadData: checkpoint has non-zero size")
+	}
+	if len(zeroCP.Hash) == 0 {
+		t.Fatal("BadTestData: checkpoint.0 has empty root hash")
+	}
+	if _, err := NewProofBuilder(context.Background(), zeroCP, rfc6962.DefaultHasher.HashChildren, testLogFetcher); err != nil {
+		t.Fatalf("NewProofBuilder: %v", err)
 	}
 }

--- a/testdata/build_log.sh
+++ b/testdata/build_log.sh
@@ -7,17 +7,19 @@ DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 export LOG=${DIR}/log
 export SERVERLESS_LOG_PRIVATE_KEY="PRIVATE+KEY+astra+cad5a3d2+ASgwwenlc0uuYcdy7kI44pQvuz1fw8cS5NqS8RkZBXoy"
 export SERVERLESS_LOG_PUBLIC_KEY="astra+cad5a3d2+AZJqeuyE/GnknsCNh1eCtDtwdAwKBddOlS8M2eI1Jt4b"
+export ORIGIN="example.com/testdata"
 
 cd ${DIR}
 rm -fr log
 
-go run ../cmd/integrate --logtostderr --storage_dir=${LOG} --initialise
+go run ../cmd/integrate --storage_dir=${LOG} --initialise --origin="${ORIGIN}"
+cp ${LOG}/checkpoint ${LOG}/checkpoint.0
 
 export LEAF=`mktemp`
 for i in one two three four five six seven eit nain ten ileven twelf threeten fourten fivten; do
   echo -n "$i" > ${LEAF}
-  go run ../cmd/sequence --storage_dir=${LOG} --entries="${LEAF}"
-  go run ../cmd/integrate --logtostderr --storage_dir=${LOG}
+  go run ../cmd/sequence --storage_dir=${LOG} --origin="${ORIGIN}" --entries="${LEAF}"
+  go run ../cmd/integrate --storage_dir=${LOG} --origin="${ORIGIN}"
   size=$(sed -n '2 p' ${LOG}/checkpoint)
   cp ${LOG}/checkpoint ${LOG}/checkpoint.${size}
 done

--- a/testdata/log/checkpoint
+++ b/testdata/log/checkpoint
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 15
 rKbDipCvhuX1GZ7g5BBe8sA6BbJ7ja/1nk427v383cs=
 
-— astra ytWj0p9x/0D9yUQ40+VjMGRUcGq/xIcFWeMdwQLBn2uqpDdLGrdW07vmGeKPuU8ergn/ys3VUZb8sVYDXQ8Ej6Q1mQE=
+— astra ytWj0iUyv3abfvt9ea52PCdTsNBiHBss+L7Z1nMhVcsoh+Re7YASWz78PrjiocC8gvkBUaDrV2Y3Ez2THNxCWnbpkQE=

--- a/testdata/log/checkpoint.0
+++ b/testdata/log/checkpoint.0
@@ -1,0 +1,5 @@
+example.com/testdata
+0
+47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+
+— astra ytWj0vyk8mOOKGTcc4inCsUD4jQTYNX/r820NAqdU6Fsj8PpEU+m74Z6SMW0BGapHgIw2xsYd9P3+E8PdXWcj0zTeAs=

--- a/testdata/log/checkpoint.1
+++ b/testdata/log/checkpoint.1
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 1
 0Nc2CrefWKseHj/mStd+LqC8B+NrX0btIiPt2SmN+ek=
 
-— astra ytWj0g061HJ64HWUdMajeRxZ88IAbVvlnxxL90iL7XeP82Pj9TuYFpgjpvQ+nCPwkbPdjeKt2gcDcMq2Rv1sXamtPg4=
+— astra ytWj0qJ+vbcrczZs9oOK0B9o0Z2H0BJB+ekrNMeJclrjpCY60XqAE5CJV9q6jRnUqthwdpkXLMhxCkv/7OUUCtZvNwM=

--- a/testdata/log/checkpoint.10
+++ b/testdata/log/checkpoint.10
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 10
 y8/gZsZCtitsMan09tY+k8I7Qpr7Y5fbO2tLi9GQnfU=
 
-— astra ytWj0sMYFxlXdp8X9GpDk5ZqejeFVyDGgmqPc1LrrG8aLxrecfVbBaobsWTB6CFjZqEDaj1oXf9gGwJtMGbyjtWdfw4=
+— astra ytWj0vy8CYTO6BiXMpCn3a9TC4NrU5dzXyTp3I52DXDtO7AJAd60D0v+cuAw4TaSPz/bynWW4jTkj2q6/TRSTfzXwgQ=

--- a/testdata/log/checkpoint.11
+++ b/testdata/log/checkpoint.11
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 11
 Yok1cS5VdokGLBy73BC2I16b3atss6KBN9jnIi6Fz/A=
 
-— astra ytWj0mOZN49FaPlp6RCDA+Us0NxUkb72Y1IAiIrp91QyyUKWKDQiG8LVMhvC3CWmaUobaJUahG7Xk6zdKAH9ZDkGYA4=
+— astra ytWj0omfGzZ0zxlY8JFZokkI8Z7px2eAY8UdMFbAt1Cweqg+caN6xcOMxxpFz0xHciHBkWsmg45qwfPQxGiQH/SibAY=

--- a/testdata/log/checkpoint.12
+++ b/testdata/log/checkpoint.12
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 12
 uZo6M+IhVna+CLgWCrJs0xBPUHbozHkYTQASduHSLME=
 
-— astra ytWj0gd8Uqx/3MAvC7DZ7eosgwofNfoDzETCvWrspV7nXp3TOBUhnjS1ibSQ12O4XnbpbiAWjGdjiRU81nbosBFaaAY=
+— astra ytWj0kRBzdccQFu4IXx3NLOdZn84CkdyPeHs+9J0hKomAJEz/fP+lMmY2cQ9WWh9qNzvNhR+knpKgKWWCCyAU4b5hw4=

--- a/testdata/log/checkpoint.13
+++ b/testdata/log/checkpoint.13
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 13
 av0kLH0VkkVDrTuZzBGIx7d9z5G1l/GlKz/nAV/8woQ=
 
-— astra ytWj0ijdzbqBRqZym2oNxvYMI2LsmH8Xk4hmYrPME1QnAtwIHAfIcGINt7VmImgtaOrSMF+e44gnNRJylq9lfNe01Qk=
+— astra ytWj0mGI7Qtgio2aXV9ScWa+TLp5b05s6oW9ot698HWC03uQR//7FoxWqD6m+L78OzhiJTWUWnfQ1fHvrS7TU8azWQM=

--- a/testdata/log/checkpoint.14
+++ b/testdata/log/checkpoint.14
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 14
 SvCd38yNade7xEPY1a/aAc1M3A2AHYVF8lIiUnsH1ao=
 
-— astra ytWj0uQsP6ctz3pju4tXlSFDSxrmAc9hXnWH1pC2eyoQdwf5SLETU7nJL1lX4v/3XrYMkc/5D3wetoWqdP2wNiAVfAk=
+— astra ytWj0ggzIhG5oKP/aDQswtPy4K6isUFRcNPXnJAzd0f5KcYrbgmRDI4Na6WYw6eQXOscao6xwSkcyGMw8FXkTbzcdgo=

--- a/testdata/log/checkpoint.15
+++ b/testdata/log/checkpoint.15
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 15
 rKbDipCvhuX1GZ7g5BBe8sA6BbJ7ja/1nk427v383cs=
 
-— astra ytWj0p9x/0D9yUQ40+VjMGRUcGq/xIcFWeMdwQLBn2uqpDdLGrdW07vmGeKPuU8ergn/ys3VUZb8sVYDXQ8Ej6Q1mQE=
+— astra ytWj0iUyv3abfvt9ea52PCdTsNBiHBss+L7Z1nMhVcsoh+Re7YASWz78PrjiocC8gvkBUaDrV2Y3Ez2THNxCWnbpkQE=

--- a/testdata/log/checkpoint.2
+++ b/testdata/log/checkpoint.2
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 2
 T1X2GdkhUjV3iyufF9b0kVsWFxIU0VI4EpNml2Teci4=
 
-— astra ytWj0o1IwU2QBohlfPBajB8cr//9E01gsX+NDwI7mXVpUJjELCT1vMFiSM2CV6kyGqXTbGbufTqN9toH5G6ilAPYLA0=
+— astra ytWj0hjRw9ubRMzxxs+mNZaMlB9++99U9CUeomuJ+GkPOb+/fcbOk4mWcWEG6P0QW5saBs7v+GRFOfaPQg5+8GxXxgg=

--- a/testdata/log/checkpoint.3
+++ b/testdata/log/checkpoint.3
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 3
 Wqx3HImawpLnS/Gv4ubjAvi1WIOy0b8Ze0amvqbavKk=
 
-— astra ytWj0rWQYuM78WAvAdo9NaqhaRExfYSV6LkXOFTpAWudxWCR8V8KaE/DLK5kU4Knl4Me5zhBlpRz+6kz0OIw94aXZg8=
+— astra ytWj0ueOKrf0tsoN1fnZzOcNi+KmijMdhv9niviS99k+jv3beiTCfPK0CVbltoKci4j0gFT5Lmm2zDl5xF9aFg87+gc=

--- a/testdata/log/checkpoint.4
+++ b/testdata/log/checkpoint.4
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 4
 zY1lN35vrXYAPixXSd59LsU29xUJtuW4o2dNNg5Y2Co=
 
-— astra ytWj0lax23JcfiEmmPd5sDYk7lSZd7l7n00OdA9ApfUfoMNKFhuXgvrhj0FOcpJFhJEWqGc8YiTJaSMp+5ng+1/BNQg=
+— astra ytWj0nB8tPqDn24svaVacHS7B4QftyzoBsxVVHBiAY9jR24WwxScVLzLzqEKw/GsKz1/ytIx94on45wiDlgMgXOMrws=

--- a/testdata/log/checkpoint.5
+++ b/testdata/log/checkpoint.5
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 5
 gy5gl3aksFyiCO95a/1vLXz88A3dRq+0l9Sxte8ZqZQ=
 
-— astra ytWj0gxqvnnS09RHRkVLOk9mxn/9WhbstMJdEetuILfXE/5F7PhPGsgbB7OkRRoTk7iKtXNUV5syah9iwEtPs++fGwU=
+— astra ytWj0sl3hjBnXaGvpD2sl/C0yObGIWtOeHjIASoBnKzhFYiJ/8g6hrzIQw/nLvcZEdc5It/ydHam4e3SOwvxz3R/qgM=

--- a/testdata/log/checkpoint.6
+++ b/testdata/log/checkpoint.6
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 6
 a6sWvsc2eEzmj72vah7mZ5dwFltivehh2b11qwlp5Jg=
 
-— astra ytWj0oses6jMO9NHGlw3ClZhjl4aW6si0yRqbhBh2n7tlMaHZsz+HRDh8e9NiUu2AcrXnUzINq3nqwnZcYsQqrGuXgg=
+— astra ytWj0v8bVfJyM+jmybi9OwGPU5CVfG/fiq3eQcZ+VjCQ1FmE2Ilbi9Mbx/90uZyHGFZ7dLD8x46SIjUnZFSClXePuQQ=

--- a/testdata/log/checkpoint.7
+++ b/testdata/log/checkpoint.7
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 7
 IrSXADBqJ7EQoUODSDKROySgNveeL6CFhik2w/+fS7U=
 
-— astra ytWj0kWX+euPIOKOrFRm9itH/hEwtnAPZ99N/8fwzTXoKVU/8KZLO7bZ40jQ3abkL1U1TimnM7HmugGkSkL0lDvM7A0=
+— astra ytWj0mbLo8zw6TpvMVTJMPVVaZTul3QfYjC4BpORAFiglmHyFihMwVJHiHXWQmyyeCdPRKAaj8YpHEKjBfDMmKPL9Q0=

--- a/testdata/log/checkpoint.8
+++ b/testdata/log/checkpoint.8
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 8
 bC+VwvrJbalNVjfkdI8kUgs7mJoXrqiXCE7bgnD28pY=
 
-— astra ytWj0uF3nDxLh4q8KZmmxtp+betExUbrP6pchbWRwpk4uS7sqrbE3hZRdgH4+6tUILG+5i3GqOWlkgNMhYKrzRNt9gc=
+— astra ytWj0vwkDwABoRkcTQlqDTO6gxjPW5yJKQ3ohF0v+6eQCGG3R2HRbQisMteoio9aJJp04zHT6WuVLQRO+XON8qAzzgY=

--- a/testdata/log/checkpoint.9
+++ b/testdata/log/checkpoint.9
@@ -1,5 +1,5 @@
-Log Checkpoint v0
+example.com/testdata
 9
 CvhHViE3S9E3htHLR+25mapWoGCJ3WckMq1UtC3VmEY=
 
-— astra ytWj0jOnlFOeXifLScHfiNG6QLrzpz5yD8tby0FRfXZi3bB6tD12n4ZqnahTag7a0ZIkC5d4/vA1WYvIrgbUG1frSgg=
+— astra ytWj0p3+4cahzXg243Bi/EJ5hMKipsU5Zl8+7hbgqgzd+c2Qgy1N9pLkcDMUkrlj/aP0a1oyAkjMF7hjFiRkuCgs8gs=


### PR DESCRIPTION
This PR fixes #60.

By _convention_ zero sized trees often define their root hash to be `SHA256("")`, but this is not reconstructible by any means, nor used in any consistency proof (all non zero trees are by definition consistent with a zero sized tree). So don't try to verify the correctness of this hash.