### PR TITLE
Init klog properly in cmds

### DIFF
--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -90,6 +90,7 @@ func usage() {
 }
 
 func main() {
+	klog.InitFlags(nil)
 	flag.Parse()
 	ctx := context.Background()
 

--- a/cmd/generate_keys/main.go
+++ b/cmd/generate_keys/main.go
@@ -33,6 +33,7 @@ var (
 )
 
 func main() {
+	klog.InitFlags(nil)
 	flag.Parse()
 
 	if len(*keyName) == 0 {

--- a/cmd/integrate/main.go
+++ b/cmd/integrate/main.go
@@ -40,6 +40,7 @@ var (
 )
 
 func main() {
+	klog.InitFlags(nil)
 	flag.Parse()
 	ctx := context.Background()
 

--- a/cmd/sequence/main.go
+++ b/cmd/sequence/main.go
@@ -42,6 +42,7 @@ var (
 )
 
 func main() {
+	klog.InitFlags(nil)
 	flag.Parse()
 
 	// Read log public key from file or environment variable


### PR DESCRIPTION
This PR fixes the missing `klog`-related flags.