### PR TITLE
Remove generation iteration after writing checkpoint.

### DIFF
--- a/experimental/gcp-log/internal/storage/storage.go
+++ b/experimental/gcp-log/internal/storage/storage.go
@@ -141,7 +141,12 @@ func (c *Client) SetNextSeq(num uint64) {
 }
 
 // WriteCheckpoint stores a raw log checkpoint on GCS if it matches the
-// generation that the client thinks the checkpoint is.
+// generation that the client thinks the checkpoint is. The client updates the
+// generation number of the checkpoint whenever ReadCheckpoint is called.
+//
+// This method will fail to write if 1) the checkpoint exists and the client
+// has never read it or 2) the checkpoint has been updated since the client
+// called ReadCheckpoint.
 func (c *Client) WriteCheckpoint(ctx context.Context, newCPRaw []byte) error {
 	bkt := c.gcsClient.Bucket(c.bucket)
 	obj := bkt.Object(layout.CheckpointPath)
@@ -160,7 +165,6 @@ func (c *Client) WriteCheckpoint(ctx context.Context, newCPRaw []byte) error {
 	if _, err := w.Write(newCPRaw); err != nil {
 		return err
 	}
-	c.checkpointGen++
 	return w.Close()
 }
 


### PR DESCRIPTION
Generation numbers are only monotonically increasing and not necessarily `[0, 1, 2, ...]` (FYI: metageneration numbers are): example [here](https://cloud.google.com/storage/docs/object-versioning#example).

Remove code assuming the generation number of the new version after writing a checkpoint. Practically speaking, if there is no race condition, a client's knowledge about the checkpoint generation will match the truth in GCS, since the client always calls ReadCheckpoint before WriteCheckpoint. If there is a race condition, then a client's knowledge about the checkpoint generation will be out of date, and the write will fail because the precondition of the generation number will not match.