### PR TITLE
Changes to Origin

### DIFF
--- a/api/state.go
+++ b/api/state.go
@@ -23,9 +23,6 @@ import (
 	"strings"
 )
 
-// CheckpointHeaderV0 is the first line of a marshaled log checkpoint.
-const CheckpointHeaderV0 = "Log Checkpoint v0"
-
 // Tile represents a subtree tile, containing inner nodes of a log tree.
 type Tile struct {
 	// NumLeaves is the number of entries at level 0 of this tile.

--- a/testdata/log.go
+++ b/testdata/log.go
@@ -32,7 +32,7 @@ const (
 	TestLogSecretKey = "PRIVATE+KEY+astra+cad5a3d2+ASgwwenlc0uuYcdy7kI44pQvuz1fw8cS5NqS8RkZBXoy"
 	TestLogPublicKey = "astra+cad5a3d2+AZJqeuyE/GnknsCNh1eCtDtwdAwKBddOlS8M2eI1Jt4b"
 
-	TestLogOrigin = "Log Checkpoint v0"
+	TestLogOrigin = "example.com/testdata"
 )
 
 var (


### PR DESCRIPTION
The CheckpointHeaderV0 should never be used and is an artifacts of a strange couple of days from history that must not be spoken about. Origin should be unique and identify the log, thus such a constant is dangerous.

Fixed the const in the test data to use the origin string that is actually used.
