### PR TITLE
Refactor the readers to have a single reader class

### DIFF
--- a/hammer/clients.go
+++ b/hammer/clients.go
@@ -84,7 +84,7 @@ func (r *LeafReader) Run(ctx context.Context) {
 		klog.V(2).Infof("LeafReader getting %d", i)
 		_, err := r.getLeaf(ctx, i, size)
 		if err != nil {
-			r.errchan <- fmt.Errorf("Failed to get leaf: %v", err)
+			r.errchan <- fmt.Errorf("failed to get leaf: %v", err)
 		}
 	}
 }
@@ -184,26 +184,26 @@ func (r *LogWriter) Run(ctx context.Context) {
 		newLeaf := r.gen()
 		resp, err := http.Post(r.u.String(), "application/octet-stream", bytes.NewReader(newLeaf))
 		if err != nil {
-			r.errchan <- fmt.Errorf("Failed to write leaf: %v", err)
+			r.errchan <- fmt.Errorf("failed to write leaf: %v", err)
 			continue
 		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			r.errchan <- fmt.Errorf("Failed to read body: %v", err)
+			r.errchan <- fmt.Errorf("failed to read body: %v", err)
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
-			r.errchan <- fmt.Errorf("Write leaf was not OK. Status code: %d. Body: %q", resp.StatusCode, body)
+			r.errchan <- fmt.Errorf("write leaf was not OK. Status code: %d. Body: %q", resp.StatusCode, body)
 			continue
 		}
 		if resp.Request.Method != http.MethodPost {
-			r.errchan <- fmt.Errorf("Write leaf was redirected to %s", resp.Request.URL)
+			r.errchan <- fmt.Errorf("write leaf was redirected to %s", resp.Request.URL)
 			continue
 		}
 		parts := bytes.Split(body, []byte("\n"))
 		index, err := strconv.Atoi(string(parts[0]))
 		if err != nil {
-			r.errchan <- fmt.Errorf("Write leaf failed to parse response: %v", body)
+			r.errchan <- fmt.Errorf("write leaf failed to parse response: %v", body)
 			continue
 		}
 

--- a/hammer/hammer.go
+++ b/hammer/hammer.go
@@ -117,14 +117,14 @@ func NewHammer(tracker *client.LogStateTracker, f client.Fetcher, addURL *url.UR
 	writeThrottle := NewThrottle(*maxWriteOpsPerSecond)
 	errChan := make(chan error, 20)
 
-	randomReaders := make([]*RandomLeafReader, *numReadersRandom)
-	fullReaders := make([]*FullLogReader, *numReadersFull)
+	randomReaders := make([]*LeafReader, *numReadersRandom)
+	fullReaders := make([]*LeafReader, *numReadersFull)
 	writers := make([]*LogWriter, *numWriters)
 	for i := 0; i < *numReadersRandom; i++ {
-		randomReaders[i] = NewRandomLeafReader(tracker, f, *leafBundleSize, readThrottle.tokenChan, errChan)
+		randomReaders[i] = NewLeafReader(tracker, f, RandomNextLeaf(), *leafBundleSize, readThrottle.tokenChan, errChan)
 	}
 	for i := 0; i < *numReadersFull; i++ {
-		fullReaders[i] = NewFullLogReader(tracker, f, *leafBundleSize, readThrottle.tokenChan, errChan)
+		fullReaders[i] = NewLeafReader(tracker, f, MonotonicallyIncreasingNextLeaf(), *leafBundleSize, readThrottle.tokenChan, errChan)
 	}
 	for i := 0; i < *numWriters; i++ {
 		writers[i] = NewLogWriter(addURL, gen, writeThrottle.tokenChan, errChan)
@@ -141,8 +141,8 @@ func NewHammer(tracker *client.LogStateTracker, f client.Fetcher, addURL *url.UR
 }
 
 type Hammer struct {
-	randomReaders []*RandomLeafReader
-	fullReaders   []*FullLogReader
+	randomReaders []*LeafReader
+	fullReaders   []*LeafReader
 	writers       []*LogWriter
 	readThrottle  *Throttle
 	writeThrottle *Throttle


### PR DESCRIPTION
The strategy for choosing the next leaf to read is now dictated by a
function. This allows much of the logic to be simplified and the getLeaf
function can now become an method of the reader, which avoids needing to
pass in as many parameters.
