### PR TITLE
Fix the throttle oversupply counting

### DIFF
--- a/hammer/hammer.go
+++ b/hammer/hammer.go
@@ -236,7 +236,6 @@ func (t *Throttle) Decrease() {
 
 func (t *Throttle) Run(ctx context.Context) {
 	ticker := time.NewTicker(1 * time.Second)
-Loop:
 	for {
 		select {
 		case <-ctx.Done(): //context cancelled
@@ -244,6 +243,7 @@ Loop:
 		case <-ticker.C:
 			tokenCount := t.opsPerSecond
 			timeout := time.After(1 * time.Second)
+		Loop:
 			for i := 0; i < tokenCount; i++ {
 				select {
 				case t.tokenChan <- true:


### PR DESCRIPTION
The previous implementation had false positives for oversupply when the
limit was increased at runtime due to the channel not being drained than
the for loop could put 2N tokens in N pigeonholes.

The new implementation uses a timeout for each episode of the throttle
that will terminate the for loop early if the tokens can't all be sent
down the channel. I considered using the next tick of the main ticker as
the timeout, but this would have caused the next episode of the throttle
to be skipped without more complexity being added.
