### PR TITLE
Added a local cache for each reader

### DIFF
--- a/hammer/clients.go
+++ b/hammer/clients.go
@@ -59,7 +59,7 @@ type LeafReader struct {
 	throttle   <-chan bool
 	errchan    chan<- error
 	cancel     func()
-	c          tileCache
+	c          leafBundleCache
 }
 
 // Run runs the log reader. This should be called in a goroutine.
@@ -120,7 +120,7 @@ func (r *LeafReader) getLeaf(ctx context.Context, i uint64, logSize uint64) ([]b
 	if l := len(bs); uint64(l) <= br {
 		return nil, fmt.Errorf("huh, short leaf bundle with %d entries, want %d", l, br)
 	}
-	r.c = tileCache{
+	r.c = leafBundleCache{
 		start:  bi * uint64(r.bundleSize),
 		leaves: bs,
 	}
@@ -136,15 +136,15 @@ func (r *LeafReader) Kill() {
 	}
 }
 
-// tileCache stores the results of the last fetched tile. This allows
+// leafBundleCache stores the results of the last fetched tile. This allows
 // readers that read contiguous blocks of leaves to act more like real
 // clients and fetch a tile of 256 leaves once, instead of 256 times.
-type tileCache struct {
+type leafBundleCache struct {
 	start  uint64
 	leaves [][]byte
 }
 
-func (tc tileCache) get(i uint64) []byte {
+func (tc leafBundleCache) get(i uint64) []byte {
 	end := tc.start + uint64(len(tc.leaves))
 	if i >= tc.start && i < end {
 		return tc.leaves[i-tc.start]

--- a/hammer/hammer.go
+++ b/hammer/hammer.go
@@ -402,6 +402,16 @@ func readHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			klog.Errorf("resp.Body.Close(): %v", err)
+		}
+	}()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read body: %v", err)
+	}
+
 	switch resp.StatusCode {
 	case 404:
 		klog.Infof("Not found: %q", u.String())
@@ -411,10 +421,5 @@ func readHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("unexpected http status %q", resp.Status)
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			klog.Errorf("resp.Body.Close(): %v", err)
-		}
-	}()
-	return io.ReadAll(resp.Body)
+	return body, nil
 }


### PR DESCRIPTION
This caches only the last tile that was fetched. This allows the full
reader in particular to act like a real client, which will consume all
of the leaves from a tile they downloaded, instead of requesting the
same tile for every leaf in it.
