### PR TITLE
Generated leaves start at the size of the tree

### DIFF
--- a/hammer/clients.go
+++ b/hammer/clients.go
@@ -85,7 +85,7 @@ func (r *LeafReader) Run(ctx context.Context) {
 		klog.V(2).Infof("LeafReader getting %d", i)
 		_, err := r.getLeaf(ctx, i, size)
 		if err != nil {
-			r.errchan <- fmt.Errorf("failed to get leaf: %v", err)
+			r.errchan <- fmt.Errorf("failed to get leaf %d: %v", i, err)
 		}
 	}
 }


### PR DESCRIPTION
Without this change the generated leaves always start at size 0, which
means many writes are squashable as duplicates on the second run of the
tool. With this change, generated leaves will be unique except where the
intended duplicate generation code kicks in.
