### PR TITLE
Limit the number of log lines buffered in the UI view

### DIFF
--- a/hammer/hammer.go
+++ b/hammer/hammer.go
@@ -308,6 +308,7 @@ func hostUI(ctx context.Context, hammer *Hammer) {
 	// Log view box
 	logView := tview.NewTextView()
 	logView.ScrollToEnd()
+	logView.SetMaxLines(10000)
 	grid.AddItem(logView, 1, 0, 1, 1, 0, 0, false)
 	if err := flag.Set("logtostderr", "false"); err != nil {
 		klog.Exitf("Failed to set flag: %v", err)


### PR DESCRIPTION
This PR puts a (currently) hard-coded limit on the number of log lines the UI buffers.

This avoids very long-running instances of the hammer from gobbling up all the RAM.