### PR TITLE
Fix: Invalid Go toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transparency-dev/serverless-log
 
-go 1.21
+go 1.21.13
 
 require (
 	github.com/gdamore/tcell/v2 v2.7.4


### PR DESCRIPTION
As of Go 1.21, toolchain versions must use the 1.N.P syntax.
