### PR TITLE
Bump Go and golangci-lint to latest version

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x]
+        go-version: [1.22.x, 1.23.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,12 +11,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.21"
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.54.1
+          version: v1.60.3

--- a/experimental/gcp-log/gcs_uploader/go.mod
+++ b/experimental/gcp-log/gcs_uploader/go.mod
@@ -1,6 +1,6 @@
 module github.com/gcp_serverless_example_module
 
-go 1.21
+go 1.22.7
 
 require cloud.google.com/go/storage v1.33.0
 

--- a/experimental/gcp-log/go.mod
+++ b/experimental/gcp-log/go.mod
@@ -1,6 +1,6 @@
 module github.com/gcp_serverless_module
 
-go 1.21
+go 1.22.7
 
 require (
 	cloud.google.com/go/kms v1.15.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transparency-dev/serverless-log
 
-go 1.21.13
+go 1.22.7
 
 require (
 	github.com/gdamore/tcell/v2 v2.7.4


### PR DESCRIPTION
Unblock https://github.com/transparency-dev/serverless-log/pull/189.