### PR TITLE
Bumped go tooling to latest

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.24.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,4 +19,4 @@ jobs:
         uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.63.4
+          version: v1.64.2

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,4 +19,4 @@ jobs:
         uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.60.3
+          version: v1.63.4

--- a/experimental/gcp-log/gcs_uploader/go.mod
+++ b/experimental/gcp-log/gcs_uploader/go.mod
@@ -1,6 +1,8 @@
 module github.com/gcp_serverless_example_module
 
-go 1.22.7
+go 1.24.0
+
+toolchain go1.24.1
 
 require cloud.google.com/go/storage v1.33.0
 

--- a/experimental/gcp-log/go.mod
+++ b/experimental/gcp-log/go.mod
@@ -1,7 +1,8 @@
 module github.com/gcp_serverless_module
 
-go 1.22.7
-toolchain go1.23.7
+go 1.24.0
+
+toolchain go1.24.1
 
 require (
 	cloud.google.com/go/kms v1.15.5

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/transparency-dev/serverless-log
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.1
 
 require (
 	github.com/gdamore/tcell/v2 v2.8.1


### PR DESCRIPTION
This makes all go.mod files consistent in this repo, and matches the tooling actually used in the Dockerfile. It should also unblock #264 which was otherwise making an odd proposal with respect to the go version and toolchain version.
