### PR TITLE
Remove codecov

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -14,5 +14,4 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
-    - uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+    - run: go test -race ./...


### PR DESCRIPTION
It's noisy and unhelpful, see #290 as an example. It's got itself stuck with some base commit in the past, and it's not worth the effort in untangling this IMO. I don't remember the last time we requested a PR was modified as a result of codecov feedback.
